### PR TITLE
Fix/exercise end date wrongly being assigned to ref p end date

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ class Config(object):
     DEBUG = os.getenv('DEBUG', False)
     TESTING = False
     NAME = 'ras-frontstage-api'
-    VERSION = os.getenv('VERSION', '0.2.0')
+    VERSION = os.getenv('VERSION', '0.2.1')
     PORT = os.getenv('PORT', 8083)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ class Config(object):
     DEBUG = os.getenv('DEBUG', False)
     TESTING = False
     NAME = 'ras-frontstage-api'
-    VERSION = os.getenv('VERSION', '0.1.2')
+    VERSION = os.getenv('VERSION', '0.2.0')
     PORT = os.getenv('PORT', 8083)
     LOGGING_LEVEL = os.getenv('LOGGING_LEVEL', 'INFO')
     SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME')

--- a/frontstage_api/controllers/eq_payload.py
+++ b/frontstage_api/controllers/eq_payload.py
@@ -88,7 +88,7 @@ class EqPayload(object):
         collex_events = collection_exercise_controller.get_collection_exercise_events(collex_id)
         return {
              "ref_p_start_date": self._find_event_date_by_tag('ref_period_start', collex_events, collex_id),
-             "ref_p_end_date": self._find_event_date_by_tag('exercise_end', collex_events, collex_id),
+             "ref_p_end_date": self._find_event_date_by_tag('ref_period_end', collex_events, collex_id),
              "return_by": self._find_event_date_by_tag('return_by', collex_events, collex_id)
         }
 


### PR DESCRIPTION
Does what it says on the tin. Tested an RSI launch locally and demonstrated to the business that the RSI end date is now showing correctly